### PR TITLE
Make transition time configurable

### DIFF
--- a/apps/hue_dimmer_switch_deconz/hue_dimmer_switch_deconz.py
+++ b/apps/hue_dimmer_switch_deconz/hue_dimmer_switch_deconz.py
@@ -32,6 +32,10 @@ class HueDimmerSwitch(Hass):
         self.light = entities["light"]
         self.switch = entities["switch"]
 
+        #config transitiontime
+        self.transitiontime = int(self.args["transitiontime"])*10 if "transitiontime" in self.args else 50
+        self.log(f"Setting transitiontime to: {self.transitiontime}")
+
         # get the advanced button config
         self.button_config = self.args.get("advanced", {})
 
@@ -87,7 +91,7 @@ class HueDimmerSwitch(Hass):
             "deconz/configure",
             field=self.deconz_field,
             entity=self.light,
-            data={"bri_inc": bri_inc, "transitiontime": 50}
+            data={"bri_inc": bri_inc, "transitiontime": self.transitiontime}
         )
 
     def stop_dim_light(self) -> None:

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ dimmer_bedroom:
   entities:
     switch: dimmer_switch_bedroom
     light: light.bedroom
+  transitiontime: 3
 ```
 #### Configuration
 key | optional | type | default | description
@@ -35,6 +36,7 @@ key | optional | type | default | description
 `module` | False | string | hue_dimmer_switch | The module name of the app.
 `class` | False | string | HueDimmerSwitch | The name of the Class.
 `entities` | True | map | | Light and switch entities.
+`transitiontime` | True | int | 5 | Transition time in sec.
 
 ##### Entities
 key | optional | type | default | description
@@ -102,6 +104,7 @@ key | optional | type | default | description
 `class` | False | string | HueDimmerSwitch | The name of the Class.
 `entities` | True | map | | Light and switch entities.
 `advanced` | True | map | | Advanced button configuration, each entry needs to be one of the available button presses.
+`transitiontime` | True | int | 5 | Transition time in sec.
 
 ##### Entities
 key | optional | type | default | description


### PR DESCRIPTION
Allows for setting the transitiontime through the yaml config. Defaults to the previous value (5=>50) if unset.